### PR TITLE
Add apacite compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ which are supplied in the `\documentclass{}` call, e.g., `\documentclass[masters
   + The signatures page is omitted.
   + The main title page is omitted.
   + Chapters do not trigger a page break.
+- **`apacite`**: allows for the use of apacite with natbib.
 
 All of these can be used in combination, separated by commas.
 The few options that have overlapping effects will give priority to the last-listed argument(s) in the listings above.

--- a/utexasthesis.cls
+++ b/utexasthesis.cls
@@ -7,9 +7,11 @@
 \newif\if@masters\@mastersfalse
 \newif\if@copyright\@copyrightfalse
 \newif\if@draft\@draftfalse
+\newif\if@apacite\@apacitefalse
 % handle optional arguments
 \DeclareOption{masters}{\@masterstrue}
 \DeclareOption{copyright}{\@copyrighttrue}
+\DeclareOption{apacite}{\@apacitetrue}
 \DeclareOption{draft}{\@drafttrue\PassOptionsToClass{draft}{report}}
 % capture the basic setspace package options for passing into setspace later
 \def\@setspaceoption{onehalfspacing}
@@ -42,8 +44,11 @@
 % LaTeX's default \parindent is 1.5em (=18pt), which falls within the legal range.
 % \setlength{\parindent}{1.5em}
 
+\if@apacite
+\RequirePackage[natbibapa]{apacite}
+\else
 \RequirePackage{natbib}
-\setcitestyle{round,comma,yysep={;}}
+\fi
 
 % table of contents configuration
 \RequirePackage[nottoc]{tocbibind}

--- a/utexasthesis.cls
+++ b/utexasthesis.cls
@@ -50,6 +50,8 @@
 \RequirePackage{natbib}
 \fi
 
+\setcitestyle{round,comma,yysep={;}}
+
 % table of contents configuration
 \RequirePackage[nottoc]{tocbibind}
 \RequirePackage{tocloft}


### PR DESCRIPTION
I certainly understand if you don't want to merge this into your repository, but I thought I'd offer this fix.

Apacite is (as I understand) generally considered the most up-to-date in terms of APA style citations. In order to use apacite and natbib together you have to call them all at once in your preamble like so:

\RequirePackage[natbibapa]{apacite}

When I tried to use the style (which is incredibly helpful, thank you!) I had a great deal of trouble getting it to work because of the _extremely helpful_ nature of LaTeX errors (not your fault), because if you have both a call to the natbib package and the call to apacite with the natbib crosswalk the whole thing breaks spectacularly.  I just added an option to use the apacite call call instead of the natbib call, by default it'll work the way it always has.

I will admit to not having much experience editing styles so there could be some very good reason why this isn't a great idea.

Thanks again for this great style!